### PR TITLE
Workaround for Sundials.jl IDA issue: remove save_start=false

### DIFF
--- a/examples/PTBClarkson2014/PALEO_examples_PTB3box.jl
+++ b/examples/PTBClarkson2014/PALEO_examples_PTB3box.jl
@@ -46,7 +46,7 @@ PALEOmodel.ODE.integrateDAEForwardDiff(
    solvekwargs=(
       abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
       reltol=1e-5,
-      save_start=false, 
+      # save_start=false, # fails with Sundials.jl 4.19.1
       dtmax=0.5e5, # , tstops=[-251.95e6]))
    )
 )

--- a/examples/PTBClarkson2014/runtests.jl
+++ b/examples/PTBClarkson2014/runtests.jl
@@ -34,7 +34,7 @@ skipped_testsets = [
         solvekwargs=(
             abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
             reltol=1e-5,
-            save_start=false,
+            # save_start=false, # fails with Sundials.jl 4.19.1
             dtmax=0.5e5,
         )
     )

--- a/examples/ocean3box/PALEO_examples_oaonly.jl
+++ b/examples/ocean3box/PALEO_examples_oaonly.jl
@@ -46,7 +46,7 @@ PALEOmodel.ODE.integrateDAEForwardDiff(
    alg=IDA(linear_solver=:KLU),
    solvekwargs=(
       abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
-      save_start=false
+      # save_start=false, # fails with Sundials.jl 4.19.1
    )
 )
 

--- a/examples/ocean3box/PALEO_examples_oaonly_abiotic.jl
+++ b/examples/ocean3box/PALEO_examples_oaonly_abiotic.jl
@@ -51,7 +51,7 @@ PALEOmodel.ODE.integrateDAEForwardDiff(
    alg=IDA(linear_solver=:KLU),
    solvekwargs=(
       abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
-      save_start=false
+      # save_start=false, # fails with Sundials.jl 4.19.1
    )
 )
 

--- a/examples/ocean3box/PALEO_examples_oaopencarb.jl
+++ b/examples/ocean3box/PALEO_examples_oaopencarb.jl
@@ -43,7 +43,7 @@ PALEOmodel.ODE.integrateDAEForwardDiff(
    alg=IDA(linear_solver=:KLU),
    solvekwargs=(
       abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all), # required to handle H2S -> 0.0
-      save_start=false
+      # save_start=false, # fails with Sundials.jl 4.19.1
    )
 )
 

--- a/examples/ocean3box/runtests.jl
+++ b/examples/ocean3box/runtests.jl
@@ -35,7 +35,7 @@ skipped_testsets = [
         alg=IDA(linear_solver=:KLU),
         solvekwargs=(
             abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
-            save_start=false
+            # save_start=false, # fails with Sundials.jl 4.19.1
         )
     )
 
@@ -83,7 +83,7 @@ end
         alg=IDA(linear_solver=:KLU),
         solvekwargs=(
             abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
-            save_start=false
+            # save_start=false, # fails with Sundials.jl 4.19.1
         )
     )
 
@@ -135,7 +135,7 @@ end
         alg=IDA(linear_solver=:KLU),
         solvekwargs=(
             abstol=1e-6*PALEOmodel.get_statevar_norm(modeldata.solver_view_all),
-            save_start=false
+            # save_start=false, # fails with Sundials.jl 4.19.1
         )
     )
 


### PR DESCRIPTION
https://github.com/SciML/Sundials.jl/issues/412

Sundials.jl v4.19.1 IDA fails with save_start=false option

Workaround: remove this (the only reason it is there in PALEO is to avoid saving the initial conditions prior to solving for algebraic constraints. Looks like there is work-in-progress in Sundials.jl to treat this more consistently in IDA, which has then introduced a bug)